### PR TITLE
Implement true partial ordering accessor functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,8 +754,7 @@ impl<T: Hash + Eq> IncrementalTopo<T> {
     ///
     /// # Examples
     /// ```
-    /// use incremental_topo::IncrementalTopo;
-    /// use std::cmp::Ordering::*;
+    /// use incremental_topo::{IncrementalTopo, TopoOrdering::*};
     /// let mut dag = IncrementalTopo::new();
     ///
     /// assert!(dag.add_node("cat"));
@@ -1151,7 +1150,7 @@ mod tests {
 
     #[test]
     fn topo_total_cmp() {
-        use std::cmp::Ordering::*;
+        use TopoOrdering::*;
         let mut dag = IncrementalTopo::new();
 
         assert!(dag.add_node("cat"));


### PR DESCRIPTION
Currently, the `IncrementalTopo` API exposes a total order via `u32` values from the `iter_unsorted` and the `descendants_unsorted` functions. It also allows for comparisons between two nodes in the graph and returning a `std::cmp::Ordering`. Currently this function just delegates to the `cmp` between the `u32` `topo_orders` of each node.

This is not wholly desirable because it does not fully represent the reality of topological ordering. While some nodes may precede or succeed other nodes (represented by `Greater` or `Less` in `std::cmp::Ordering`) based on their dependencies, other nodes can have no relation at all to each other. If there does not exist a chain of dependencies linking two nodes, either forward or backwards, then there is no order between them. 

However the current implementation delegates to the `u32` `topo_order` field which must assign a distinct, and monotonically increasing value to each node in the graph. This means that nodes will end up comparing `Greater` or `Less` even if there is no order between them.

To fix this we should first introduce a restricted `TopoOrdering` enum that only has two variants, `Greater` or `Less`. Second, we can add a new method `topo_partial_cmp` that returns `Option<TopoOrdering>`, where the `None` indicates that there is no order between the two nodes passed.

The issue with this new function is that it will do a non-trivial traversal of the graph to determine if the two nodes are indeed `Greater` or `Less` than each other.